### PR TITLE
change team member links to github profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ An open-source Patient Medical Records web application using Laravel and Vue.
 
 ### Tech Stack
 
-- [Vue](https://vuejs.org/)
-- [Laravel 7](https://laravel.com/docs/7.x)
-- [MySQL](https://www.mysql.com/)
+-   [Vue](https://vuejs.org/)
+-   [Laravel 7](https://laravel.com/docs/7.x)
+-   [MySQL](https://www.mysql.com/)
 
 ### Core Team
 
-- Team Lead: [DJ](https://www.facebook.com/djasuncion777)
-- UX/UI Design: [Resamae](https://www.facebook.com/artech127)
-- Front-end: [Vincent](https://www.facebook.com/open24times), [Charles](https://www.facebook.com/quarts14)
-- Back-end: [Magi](https://www.facebook.com/magijoy/), [Darwin](https://www.facebook.com/darwin.buelo)  
+-   Team Lead: [Jibe](https://github.com/djma777)
+-   UX/UI Design: [Resamae](https://github.com/mikie27), Mark
+-   Front-end: [Vincent](https://github.com/vbgiron), [Charles](https://github.com/Vincexx)
+-   Back-end: [Magi](https://github.com/magijoylarin), [Darwin](https://github.com/DarwinBuelo)
 
 For interested contributors, check out our contributor [guidelines](CONTRIBUTING.md).
 
@@ -23,6 +23,6 @@ For interested contributors, check out our contributor [guidelines](CONTRIBUTING
 
 In order to ensure that the community is welcoming to all, please review and abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-## License 
+## License
 
 POS System is freely available for free non-commercial use, and may be redistributed under these conditions. For commercial queries, please drop an e-mail at admin[at]devph[dot]io. We will send the detail agreement to you.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An open-source Patient Medical Records web application using Laravel and Vue.
 ### Core Team
 
 -   Team Lead: [Jibe](https://github.com/djma777)
--   UX/UI Design: [Resamae](https://github.com/mikie27), Mark
+-   UX/UI Design: [Resamae](https://github.com/mikie27), [Mark](https://github.com/markkalalo)
 -   Front-end: [Vincent](https://github.com/vbgiron), [Charles](https://github.com/Vincexx)
 -   Back-end: [Magi](https://github.com/magijoylarin), [Darwin](https://github.com/DarwinBuelo)
 


### PR DESCRIPTION
I think github profile links are more appropriate for now 